### PR TITLE
[Feature/#27] 커스텀 토스트 구현

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,8 +1,13 @@
 import { Stack } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
-import { SafeAreaView } from "react-native-safe-area-context";
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from "react-native-safe-area-context";
+import Toast from "react-native-toast-message";
 
-import { useLoadFonts } from "@shared/hooks/use-load-fonts";
+import { toastConfig } from "@config/toast.config";
+import { useLoadFonts } from "@shared/hooks";
 import { colors } from "@theme/token";
 
 SplashScreen.preventAutoHideAsync();
@@ -11,6 +16,7 @@ SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
   useLoadFonts();
+  const insets = useSafeAreaInsets();
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.black.main }}>
@@ -29,6 +35,8 @@ export default function RootLayout() {
         <Stack.Screen name="my-thip-list" options={{ headerShown: false }} />
         <Stack.Screen name="(user)" options={{ headerShown: false }} />
       </Stack>
+      <Toast config={toastConfig} position="top" topOffset={insets.top + 16} />
+      {/* <Toast position="top" topOffset={60} /> */}
     </SafeAreaView>
   );
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -15,6 +15,7 @@ module.exports = function (api) {
             "@assets": "./assets",
             "@shared": "./src/shared",
             "@theme": "./src/theme",
+            "@config": "./src/config",
             "@images/*": "./assets/images",
             "@screens/*": "./screens",
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-svg": "15.12.1",
+        "react-native-toast-message": "^2.3.3",
         "react-native-web": "~0.21.0",
         "react-native-worklets": "0.5.1"
       },
@@ -11156,6 +11157,16 @@
       "peerDependencies": {
         "react-native": ">=0.59.0",
         "react-native-svg": ">=12.0.0"
+      }
+    },
+    "node_modules/react-native-toast-message": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/react-native-toast-message/-/react-native-toast-message-2.3.3.tgz",
+      "integrity": "sha512-4IIUHwUPvKHu4gjD0Vj2aGQzqPATiblL1ey8tOqsxOWRPGGu52iIbL8M/mCz4uyqecvPdIcMY38AfwRuUADfQQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-web": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-svg": "15.12.1",
+    "react-native-toast-message": "^2.3.3",
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.5.1"
   },

--- a/screens/feed/components/my-feed-contents/index.tsx
+++ b/screens/feed/components/my-feed-contents/index.tsx
@@ -1,10 +1,19 @@
 import { router } from "expo-router";
 import { ScrollView, StyleSheet } from "react-native";
+import Toast from "react-native-toast-message";
 
 import { AppText } from "@shared/ui";
 import { colors } from "@theme/token";
 
 export default function MyFeedContents() {
+  // TODO: 토스트 메시지 테스트용. 삭제 예정
+  const handleShowToastTest = () => {
+    Toast.show({
+      type: "default",
+      text1:
+        "Hello, 엄청 긴 텍스트, 엄청 긴 텍스트엄청 긴 텍스트엄청 긴 텍스트엄청 긴 텍스트엄청 긴 텍스트엄청 긴 텍스트엄청 긴 텍스트",
+    });
+  };
   return (
     <ScrollView contentContainerStyle={styles.content}>
       <AppText
@@ -15,6 +24,15 @@ export default function MyFeedContents() {
         onPress={() => router.push("/login")}
       >
         로그인으로
+      </AppText>
+      {/* TODO: 토스트 메시지 테스트를 위한 부분 */}
+      <AppText
+        weight="extrabold"
+        size="lg"
+        color={colors.purple.sub}
+        onPress={handleShowToastTest}
+      >
+        토스트 메시지!
       </AppText>
     </ScrollView>
   );

--- a/src/config/toast.config.tsx
+++ b/src/config/toast.config.tsx
@@ -54,7 +54,6 @@ const styles = StyleSheet.create({
   container: {
     width: "80%",
     padding: 12,
-    boxSizing: "border-box",
     backgroundColor: colors.darkgrey.dark,
     borderRadius: 12,
     borderWidth: 1,

--- a/src/config/toast.config.tsx
+++ b/src/config/toast.config.tsx
@@ -1,0 +1,63 @@
+import { StyleSheet, View } from "react-native";
+import {
+  BaseToast,
+  BaseToastProps,
+  ErrorToast,
+} from "react-native-toast-message";
+
+import { AppText } from "../shared/ui";
+import { colors } from "../theme/token";
+
+export const toastConfig = {
+  /*
+    Overwrite 'success' type,
+    by modifying the existing `BaseToast` component
+  */
+  success: (props: BaseToastProps) => (
+    <BaseToast
+      {...props}
+      style={{ borderLeftColor: "pink" }}
+      contentContainerStyle={{ paddingHorizontal: 15 }}
+      text1Style={{
+        fontSize: 15,
+        fontWeight: "400",
+      }}
+    />
+  ),
+  /*
+    Overwrite 'error' type,
+    by modifying the existing `ErrorToast` component
+  */
+  error: (props: BaseToastProps) => (
+    <ErrorToast
+      {...props}
+      text1Style={{
+        fontSize: 17,
+      }}
+      text2Style={{
+        fontSize: 15,
+      }}
+    />
+  ),
+
+  // Thip 기본 토스트
+  default: (props: BaseToastProps) => (
+    <View style={styles.container}>
+      <AppText weight="medium" size="xs" color={colors.white}>
+        {props.text1}
+      </AppText>
+    </View>
+  ),
+};
+
+const styles = StyleSheet.create({
+  container: {
+    width: "80%",
+    padding: 12,
+    boxSizing: "border-box",
+    backgroundColor: colors.darkgrey.dark,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.grey[300],
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
       "@assets/*": ["./assets/*"],
       "@shared/*": ["./src/shared/*"],
       "@theme/*": ["./src/theme/*"],
+      "@config/*": ["./src/config/*"],
       "@images/*": ["./assets/images/*"],
       "@screens/*": ["./screens/*"]
     }


### PR DESCRIPTION
## 📌 Related Issues

- close #27 

## 📄 Tasks

- `react-native-toast-message` 라이브러리 설치
- 가장 상위 `/app/_layout.tsx` 파일에서 자식 중 가장 아래에 Toast 컴포넌트 추가
  - topOffset을 `useSafeAreaInsets`을 이용하여 각 디바이스 별 상단 베젤 + 16 으로 설정
- `src/config` 폴더 생성 및 `toast.config.tsx` 파일 생성
  - 토스트에 대한 커스텀 레이아웃 구현
  - default가 띱의 기본적인 토스트 ui
  - Toast 컴포넌트의 config prop으로 전달

## 📷 Screenshot

<img width="411" height="742" alt="image" src="https://github.com/user-attachments/assets/945c9608-10e8-483b-a032-7aafff839855" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
* 토스트 알림 시스템 추가
* 성공, 오류, 기본 타입 알림 지원
* 커스터마이징된 알림 디자인 적용
* 안전 영역 기반 알림 위치 지정
* 테스트용 알림 메시지 기능 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->